### PR TITLE
fix: enhance PDF metadata validation in Convert component

### DIFF
--- a/noteworthy-site/src/components/Convert/index.tsx
+++ b/noteworthy-site/src/components/Convert/index.tsx
@@ -213,8 +213,9 @@ const Convert = () => {
     isLoading ||
     Boolean(
       pdfMetadata &&
-        pdfMetadata.processType === processType &&
-        pdfMetadata.sourceFiles.length === files.length &&
+      pdfMetadata.processType === processType &&
+      pdfMetadata.sourceFiles.length === files.length &&
+      pdfMetadata.prompt === customPrompt &&
         pdfMetadata.sourceFiles.every((name, i) => files[i].name === name),
     );
 


### PR DESCRIPTION
Update the condition for loading state in the Convert component to 
include a check for the custom prompt. This ensures that the loading 
state accurately reflects all necessary criteria for processing, 
improving the reliability of the component's behavior.