### PR TITLE
feat(pdf): add PDF saving and listing functionality api

### DIFF
--- a/noteworthy-site/package-lock.json
+++ b/noteworthy-site/package-lock.json
@@ -25,6 +25,7 @@
         "next-auth": "^4.24.11",
         "next-themes": "^0.3.0",
         "nodemailer": "^6.9.12",
+        "pdf-lib": "^1.17.1",
         "prettier": "^3.1.0",
         "prettier-plugin-tailwindcss": "^0.5.7",
         "prisma": "^5.7.0",
@@ -2674,6 +2675,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -9294,6 +9313,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9362,6 +9387,24 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/noteworthy-site/package.json
+++ b/noteworthy-site/package.json
@@ -26,6 +26,7 @@
     "next-auth": "^4.24.11",
     "next-themes": "^0.3.0",
     "nodemailer": "^6.9.12",
+    "pdf-lib": "^1.17.1",
     "prettier": "^3.1.0",
     "prettier-plugin-tailwindcss": "^0.5.7",
     "prisma": "^5.7.0",

--- a/noteworthy-site/prisma/schema.prisma
+++ b/noteworthy-site/prisma/schema.prisma
@@ -48,6 +48,20 @@ model User {
   passwordResetTokenExp DateTime?
   accounts              Account[]
   sessions              Session[]
+  savedPdfs             SavedPdf[]
+}
+
+model SavedPdf {
+  id          String   @id @default(cuid())
+  title       String
+  content     Bytes
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+  userId      String
+  processType String
+  sourceFiles String[]
+  prompt      String?
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model VerificationToken {

--- a/noteworthy-site/src/app/api/pdf/combine/route.ts
+++ b/noteworthy-site/src/app/api/pdf/combine/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/utils/auth";
+import { prisma } from "@/utils/prismaDB";
+import { PDFDocument } from 'pdf-lib';
+
+export async function POST(req: NextRequest) {
+  try {
+    // Check if user is authenticated
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const userId = session.user.id;
+    if (!userId) {
+      return NextResponse.json(
+        { error: "User ID not found" },
+        { status: 401 }
+      );
+    }
+    
+    // Parse request body
+    const { pdfIds, title } = await req.json();
+    
+    if (!pdfIds || !Array.isArray(pdfIds) || pdfIds.length === 0) {
+      return NextResponse.json(
+        { error: "No PDFs selected for combining" },
+        { status: 400 }
+      );
+    }
+
+    // Fetch all the PDFs from the database
+    const pdfs = await prisma.savedPdf.findMany({
+      where: {
+        id: { in: pdfIds },
+        userId: userId as string, // Ensure the PDFs belong to the user
+      },
+    });
+
+    if (pdfs.length !== pdfIds.length) {
+      return NextResponse.json(
+        { error: "Some PDFs were not found" },
+        { status: 404 }
+      );
+    }
+
+    // Create a new PDF document
+    const mergedPdf = await PDFDocument.create();
+    
+    // Add pages from each PDF
+    for (const pdf of pdfs) {
+      const pdfDoc = await PDFDocument.load(pdf.content);
+      const copiedPages = await mergedPdf.copyPages(pdfDoc, pdfDoc.getPageIndices());
+      copiedPages.forEach((page) => {
+        mergedPdf.addPage(page);
+      });
+    }
+    
+    // Save the merged PDF
+    const mergedPdfBytes = await mergedPdf.save();
+    
+    // If title is provided, save the combined PDF to the database
+    if (title) {
+      await prisma.savedPdf.create({
+        data: {
+          title,
+          content: Buffer.from(mergedPdfBytes),
+          userId: userId as string,
+          processType: 'combined',
+          sourceFiles: pdfs.map(pdf => `Combined from: ${pdf.title}`),
+          prompt: 'Combined PDF',
+        },
+      });
+    }
+
+    // Return the merged PDF
+    const response = new NextResponse(mergedPdfBytes);
+    response.headers.set("Content-Type", "application/pdf");
+    
+    // Only set Content-Disposition header if the user requested to download it
+    // This allows the PDF to be previewed in the browser instead of being downloaded automatically
+    const downloadParam = req.nextUrl.searchParams.get('download');
+    if (downloadParam === 'true') {
+      response.headers.set(
+        "Content-Disposition", 
+        `attachment; filename="${encodeURIComponent(title || 'combined')}.pdf"`
+      );
+    }
+    
+    return response;
+  } catch (error) {
+    console.error("Error combining PDFs:", error);
+    return NextResponse.json(
+      { error: "Failed to combine PDFs" },
+      { status: 500 }
+    );
+  }
+}

--- a/noteworthy-site/src/app/api/pdf/delete/[id]/route.ts
+++ b/noteworthy-site/src/app/api/pdf/delete/[id]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/utils/auth";
+import { prisma } from "@/utils/prismaDB";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Check if user is authenticated
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    // User ID should be available because of our session callback in auth.ts
+    const userId = session.user.id;
+    if (!userId) {
+      return NextResponse.json(
+        { error: "User ID not found" },
+        { status: 401 }
+      );
+    }
+
+    const pdfId = params.id;
+
+    // Find the PDF to ensure it belongs to the user
+    const pdf = await prisma.savedPdf.findUnique({
+      where: {
+        id: pdfId,
+        userId: userId as string, // Ensure the PDF belongs to the user
+      },
+    });
+
+    if (!pdf) {
+      return NextResponse.json(
+        { error: "PDF not found" },
+        { status: 404 }
+      );
+    }
+
+    // Delete the PDF
+    await prisma.savedPdf.delete({
+      where: {
+        id: pdfId,
+      },
+    });
+
+    return NextResponse.json(
+      { message: "PDF deleted successfully" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error deleting PDF:", error);
+    return NextResponse.json(
+      { error: "Failed to delete PDF" },
+      { status: 500 }
+    );
+  }
+}

--- a/noteworthy-site/src/app/api/pdf/get/[id]/route.ts
+++ b/noteworthy-site/src/app/api/pdf/get/[id]/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/utils/auth";
+import { prisma } from "@/utils/prismaDB";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Check if user is authenticated
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const userId = session.user.id as string;
+    const pdfId = params.id;
+
+    // Find the PDF in the database
+    const pdf = await prisma.savedPdf.findUnique({
+      where: {
+        id: pdfId,
+        userId: userId as string, // Ensure the PDF belongs to the user
+      },
+    });
+
+    if (!pdf) {
+      return NextResponse.json(
+        { error: "PDF not found" },
+        { status: 404 }
+      );
+    }
+
+    // Return the PDF content
+    const response = new NextResponse(pdf.content);
+    response.headers.set("Content-Type", "application/pdf");
+    
+    // Check if the download parameter is present
+    const download = req.nextUrl.searchParams.get('download') === 'true';
+    if (download) {
+      // Set Content-Disposition to attachment for download
+      response.headers.set(
+        "Content-Disposition", 
+        `attachment; filename="${encodeURIComponent(pdf.title)}.pdf"`
+      );
+    }
+    
+    return response;
+  } catch (error) {
+    console.error("Error retrieving PDF:", error);
+    return NextResponse.json(
+      { error: "Failed to retrieve PDF" },
+      { status: 500 }
+    );
+  }
+}

--- a/noteworthy-site/src/app/api/pdf/list/route.ts
+++ b/noteworthy-site/src/app/api/pdf/list/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/utils/auth";
+import { prisma } from "@/utils/prismaDB";
+
+export async function GET(req: NextRequest) {
+  try {
+    // Check if user is authenticated
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    const userId = session.user.id as string;
+
+    // Get all PDFs for the user
+    const pdfs = await prisma.savedPdf.findMany({
+      where: {
+        userId: userId,
+      },
+      select: {
+        id: true,
+        title: true,
+        createdAt: true,
+        processType: true,
+        // Don't include the content (PDF binary data) in the list response
+      },
+      orderBy: {
+        createdAt: 'desc', // Most recent first
+      },
+    });
+
+    return NextResponse.json(pdfs);
+  } catch (error) {
+    console.error("Error listing PDFs:", error);
+    return NextResponse.json(
+      { error: "Failed to list PDFs" },
+      { status: 500 }
+    );
+  }
+}

--- a/noteworthy-site/src/app/api/pdf/preview/[id]/route.ts
+++ b/noteworthy-site/src/app/api/pdf/preview/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/utils/auth";
+import { prisma } from "@/utils/prismaDB";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    // Check if user is authenticated
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    // User ID should be available because of our session callback in auth.ts
+    const userId = session.user.id;
+    if (!userId) {
+      return NextResponse.json(
+        { error: "User ID not found" },
+        { status: 401 }
+      );
+    }
+
+    const pdfId = params.id;
+
+    // Find the PDF in the database
+    const pdf = await prisma.savedPdf.findUnique({
+      where: {
+        id: pdfId,
+        userId: userId as string, // Ensure the PDF belongs to the user
+      },
+    });
+
+    if (!pdf) {
+      return NextResponse.json(
+        { error: "PDF not found" },
+        { status: 404 }
+      );
+    }
+
+    // Return the PDF content for preview (no attachment)
+    const response = new NextResponse(pdf.content);
+    response.headers.set("Content-Type", "application/pdf");
+    // Don't set Content-Disposition to allow viewing in browser
+    
+    return response;
+  } catch (error) {
+    console.error("Error retrieving PDF:", error);
+    return NextResponse.json(
+      { error: "Failed to retrieve PDF" },
+      { status: 500 }
+    );
+  }
+}

--- a/noteworthy-site/src/app/api/pdf/save/route.ts
+++ b/noteworthy-site/src/app/api/pdf/save/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/utils/auth";
+import { prisma } from "@/utils/prismaDB";
+
+export async function POST(req: NextRequest) {
+  try {
+    // Check if user is authenticated
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    // Get user ID from session
+    const userId = session.user.id;
+    if (!userId) {
+      return NextResponse.json(
+        { error: "User ID not found" },
+        { status: 401 }
+      );
+    }
+    
+    // Parse request body
+    const formData = await req.formData();
+    const title = formData.get('title') as string;
+    const pdfBlob = formData.get('pdf') as Blob;
+    const processType = formData.get('processType') as string;
+    const sourceFiles = JSON.parse(formData.get('sourceFiles') as string);
+    const prompt = formData.get('prompt') as string || '';
+    
+    if (!title || !pdfBlob) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 }
+      );
+    }
+
+    // Convert PDF blob to buffer for database storage
+    const pdfBuffer = Buffer.from(await pdfBlob.arrayBuffer());
+
+    // Save PDF to database
+    const savedPdf = await prisma.savedPdf.create({
+      data: {
+        title,
+        content: pdfBuffer,
+        userId,
+        processType,
+        sourceFiles,
+        prompt,
+      },
+    });
+
+    return NextResponse.json(
+      { 
+        message: "PDF saved successfully", 
+        id: savedPdf.id 
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error saving PDF:", error);
+    return NextResponse.json(
+      { error: "Failed to save PDF" },
+      { status: 500 }
+    );
+  }
+}

--- a/noteworthy-site/src/types/next-auth.d.ts
+++ b/noteworthy-site/src/types/next-auth.d.ts
@@ -1,0 +1,13 @@
+import NextAuth, { DefaultSession } from "next-auth"
+
+declare module "next-auth" {
+  /**
+   * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
+   */
+  interface Session {
+    user: {
+      /** The user's id. */
+      id: string
+    } & DefaultSession["user"]
+  }
+}


### PR DESCRIPTION
Implements a new feature to save and list user PDFs. 
Adds a `SavedPdf` model to the Prisma schema to store 
PDF metadata and content. Introduces API routes for 
saving PDFs and retrieving a list of saved PDFs for 
authenticated users. This enhances user experience by 
allowing users to manage their PDFs effectively.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #10 
- <kbd>&nbsp;1&nbsp;</kbd> #9 👈 
<!-- GitButler Footer Boundary Bottom -->

