### PR TITLE
refactor: remove maxDuration constant from route.ts

### DIFF
--- a/noteworthy-site/src/app/api/latex/generate/route.ts
+++ b/noteworthy-site/src/app/api/latex/generate/route.ts
@@ -7,7 +7,6 @@ import { run } from  "./geminiIntegration"
 
 export const runtime = "nodejs";
 export const dynamic = 'force-dynamic';
-export const maxDuration = 300; // 5 minutes in seconds
 
 // This tells Next.js not to use the default body parser
 // so we can handle the request body manually with no size limit


### PR DESCRIPTION
Eliminate the maxDuration constant to allow for unlimited request 
body size handling. This change simplifies the code and enhances 
flexibility in processing requests.