### PR TITLE
fixed model names on api calls

### DIFF
--- a/noteworthy-site/src/app/api/latex/generate/geminiIntegration.js
+++ b/noteworthy-site/src/app/api/latex/generate/geminiIntegration.js
@@ -2,6 +2,15 @@ const { GoogleGenerativeAI } = require("@google/generative-ai");
 const { GoogleAIFileManager } = require("@google/generative-ai/server");
 const dotenv = require("dotenv");
 const { ok, err, Result } = require("neverthrow");
+const fs = require("fs").promises;
+const path = require("path");
+// Import PDF handler functions statically so that Next.js/webpack can bundle them
+const {
+    uploadPDFToGemini,
+    waitForPDFProcessing,
+    isPDFFile,
+    cleanupGeminiFile,
+} = require("../../../../lib/pdfHandler.js");
 
 dotenv.config();
 // Load the GEMINI_API_KEY from environment variables
@@ -35,11 +44,11 @@ function getPromptText(processType) {
 function getModel(model) {
     switch (model) {
         case "regular":
-            return "gemini-2.0-flash";
+            return "gemini-flash-latest";
         case "fast":
             return "gemini-2.0-flash-lite";
         case "pro":
-            return "gemini-2.5-pro-exp-03-25";
+            return "gemini-3-pro-preview";
     }
 }
 
@@ -215,6 +224,30 @@ async function run(
             type: "GEMINI_GENERATION_ERROR",
             error: error.message,
         });
+    } finally {
+        // Clean up PDF files in the background
+        if (pdfFilesToCleanup.length > 0) {
+            console.log("[geminiIntegration] Cleaning up PDF files...");
+            // Don't await this - do it in background to not delay response
+            cleanupPDFFiles(pdfFilesToCleanup);
+        }
+    }
+}
+
+/**
+ * Clean up PDF files from Gemini Files API (background operation)
+ * @param {string[]} fileNames - Array of file names to cleanup
+ */
+async function cleanupPDFFiles(fileNames) {
+    for (const fileName of fileNames) {
+        try {
+            await cleanupGeminiFile(fileName);
+        } catch (error) {
+            console.error(
+                `[geminiIntegration] Failed to cleanup PDF file ${fileName}:`,
+                error,
+            );
+        }
     }
 }
 

--- a/noteworthy-site/src/app/api/latex/generate/geminiIntegration.js
+++ b/noteworthy-site/src/app/api/latex/generate/geminiIntegration.js
@@ -4,13 +4,6 @@ const dotenv = require("dotenv");
 const { ok, err, Result } = require("neverthrow");
 const fs = require("fs").promises;
 const path = require("path");
-// Import PDF handler functions statically so that Next.js/webpack can bundle them
-const {
-    uploadPDFToGemini,
-    waitForPDFProcessing,
-    isPDFFile,
-    cleanupGeminiFile,
-} = require("../../../../lib/pdfHandler.js");
 
 dotenv.config();
 // Load the GEMINI_API_KEY from environment variables
@@ -224,30 +217,6 @@ async function run(
             type: "GEMINI_GENERATION_ERROR",
             error: error.message,
         });
-    } finally {
-        // Clean up PDF files in the background
-        if (pdfFilesToCleanup.length > 0) {
-            console.log("[geminiIntegration] Cleaning up PDF files...");
-            // Don't await this - do it in background to not delay response
-            cleanupPDFFiles(pdfFilesToCleanup);
-        }
-    }
-}
-
-/**
- * Clean up PDF files from Gemini Files API (background operation)
- * @param {string[]} fileNames - Array of file names to cleanup
- */
-async function cleanupPDFFiles(fileNames) {
-    for (const fileName of fileNames) {
-        try {
-            await cleanupGeminiFile(fileName);
-        } catch (error) {
-            console.error(
-                `[geminiIntegration] Failed to cleanup PDF file ${fileName}:`,
-                error,
-            );
-        }
     }
 }
 

--- a/noteworthy-site/src/app/api/latex/generate/route.ts
+++ b/noteworthy-site/src/app/api/latex/generate/route.ts
@@ -3,10 +3,10 @@ import path from "path";
 import { promises as fsPromises } from "fs";
 import os from "os";
 import { ok, err, Result } from "neverthrow";
-import { run } from  "./geminiIntegration"
+import { run } from "./geminiIntegration";
 
 export const runtime = "nodejs";
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 // This tells Next.js not to use the default body parser
 // so we can handle the request body manually with no size limit
@@ -15,7 +15,7 @@ export const config = {
     // Disable Next.js's default body parser
     bodyParser: false,
   },
-}
+};
 
 export async function POST(request: NextRequest) {
   const uploadDir = path.join(os.tmpdir(), "uploads", "temp");
@@ -63,13 +63,6 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
-  const latexCode = await run(filePaths, processType, modelType, customPrompt);
-
-  if (latexCode.isErr()) {
-  // The geminiIntegration.run helper returns neverthrow's Result but
-  // TypeScript struggles to infer the correct union from the JS file.
-  // Cast to `any` so we can safely use `.isErr()` at runtime without a
-  // compilation failure.
   // eslint-disable-next-line
   const latexCode: any = await run(
     filePaths,

--- a/noteworthy-site/src/app/api/latex/generate/route.ts
+++ b/noteworthy-site/src/app/api/latex/generate/route.ts
@@ -66,6 +66,20 @@ export async function POST(request: NextRequest) {
   const latexCode = await run(filePaths, processType, modelType, customPrompt);
 
   if (latexCode.isErr()) {
+  // The geminiIntegration.run helper returns neverthrow's Result but
+  // TypeScript struggles to infer the correct union from the JS file.
+  // Cast to `any` so we can safely use `.isErr()` at runtime without a
+  // compilation failure.
+  // eslint-disable-next-line
+  const latexCode: any = await run(
+    filePaths,
+    processType,
+    modelType,
+    customPrompt,
+  );
+
+  if (latexCode.isErr()) {
+    // eslint-disable-next-line
     const { type, error } = latexCode.error;
     const cleanupResult = await cleanUpFiles(uploadDir);
     if (cleanupResult.isErr()) {
@@ -80,6 +94,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // eslint-disable-next-line
   let cleanedLatex = latexCode.value.output.trim();
 
   if (cleanedLatex.startsWith("```latex")) {

--- a/noteworthy-site/src/components/Convert/index.tsx
+++ b/noteworthy-site/src/components/Convert/index.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import Image from "next/image";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 import toast from "react-hot-toast";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import StreamingOverlay from "../StreamingOverlay";
@@ -173,6 +173,48 @@ const Convert = () => {
       });
   };
 
+  /**
+   * Open the generated LaTeX document in Overleaf using their public "Open in Overleaf" API.
+   * Docs: https://www.overleaf.com/devs (see "Base64 Data URL" section)
+   */
+  const openInOverleaf = useCallback(() => {
+    const texSource = fullCode || latexCode;
+    if (!texSource) {
+      toast.error("No LaTeX code available yet");
+      return;
+    }
+
+    try {
+      // Build a transient form that POSTs the snippet to Overleaf, avoiding URI length limits
+      const form = document.createElement("form");
+      form.action = "https://www.overleaf.com/docs";
+      form.method = "POST";
+      form.target = "_blank"; // open in new tab
+      form.style.display = "none";
+
+      // Overleaf accepts `encoded_snip` containing URL-encoded LaTeX source
+      const encodedInput = document.createElement("input");
+      encodedInput.type = "hidden";
+      encodedInput.name = "encoded_snip";
+      encodedInput.value = encodeURIComponent(texSource);
+      form.appendChild(encodedInput);
+
+      // Pass engine so it matches local compilation (xelatex)
+      const engineInput = document.createElement("input");
+      engineInput.type = "hidden";
+      engineInput.name = "engine";
+      engineInput.value = "xelatex";
+      form.appendChild(engineInput);
+
+      document.body.appendChild(form);
+      form.submit();
+      document.body.removeChild(form);
+    } catch (err) {
+      console.error("Failed to open in Overleaf", err);
+      toast.error("Unable to open in Overleaf");
+    }
+  }, [fullCode, latexCode]);
+
   async function fetchComposedLatex(latexCode: string): Promise<string | ""> {
     try {
       const response = await fetch("/api/latex/compose", {
@@ -263,7 +305,7 @@ const Convert = () => {
     } else if (latexStatus?.status === "error") {
       setIsLoading(false);
     }
-  }, [latexStatus, files, processType, customPrompt]);
+  }, [latexStatus, files, processType, customPrompt, openInOverleaf]);
 
   // Add event listener for our custom status update
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Gemini model IDs used by LaTeX generation and adds a client-side helper to open generated LaTeX in Overleaf, plus minor API route cleanup.
> 
> - **Backend/API**
>   - Update model IDs in `getModel` (`regular` -> `gemini-flash-latest`, `pro` -> `gemini-3-pro-preview`).
>   - Minor cleanup in `api/latex/generate/route.ts` (typing, formatting, lint disables) with no logic changes.
> - **Frontend**
>   - Add `openInOverleaf` utility in `components/Convert/index.tsx` to POST LaTeX to Overleaf; include in effect deps; import `useCallback`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b3617d09d5bfa56c4c1735951339726ea5a15a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->